### PR TITLE
Feature redis storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.db
+*.coverprofile
+kala

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Kala was inspired by [Chronos](https://github.com/airbnb/chronos), developed by 
 is fault tolerant and distributed by design. These are two features which Kala does not have, as it was built for smaller deployments.
 
 It has a simple JSON over HTTP API, so it is language agnostic. It has Job Stats, Configurable Retries, uses ISO 8601 Date and Interval
-notation, Dependant Jobs, and is Persistent (using BoltDB). Eventually it will support Redis as a Backend and have a Web UI.
+notation, Dependant Jobs, and is Persistent (using BoltDB). Eventually it will have a Web UI.
 
 #### Have any feedback or bugs to report?
 
@@ -81,6 +81,12 @@ ajvb$ kala run
 
 ajvb$ kala run -p 2222
 2015/06/10 18:31:31 main.go:59:func·001 :: INFO 002 Starting server on port :2222...
+```
+
+Kala uses BoltDB by default for the job database, however you can also use Redis by using the jobDB and jobDBAddress params:
+
+```bash
+kala run --jobDB=redis --jobDBAddress=127.0.0.1:6379
 ```
 
 Kala runs on `127.0.0.1:8000` by default. You can easily test it out by curling the metrics path.

--- a/job/db.go
+++ b/job/db.go
@@ -3,7 +3,7 @@ package job
 type JobDB interface {
 	GetAll() ([]*Job, error)
 	Get(id string) (*Job, error)
-	Delete(id string)
+	Delete(id string) error
 	Save(job *Job) error
 	Close() error
 }

--- a/job/db.go
+++ b/job/db.go
@@ -1,5 +1,14 @@
 package job
 
+import "fmt"
+
+// ErrJobNotFound is raised when a Job is able to be found within a database.
+type ErrJobNotFound string
+
+func (id ErrJobNotFound) Error() string {
+	return fmt.Sprintf("Job with id of %s not found.", string(id))
+}
+
 type JobDB interface {
 	GetAll() ([]*Job, error)
 	Get(id string) (*Job, error)

--- a/job/job.go
+++ b/job/job.go
@@ -1,6 +1,8 @@
 package job
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -81,6 +83,30 @@ type Job struct {
 	Stats       []*JobStat `json:"-"`
 
 	lock sync.Mutex
+}
+
+// Bytes returns the byte representation of the Job.
+func (j Job) Bytes() ([]byte, error) {
+	buff := new(bytes.Buffer)
+	enc := gob.NewEncoder(buff)
+	err := enc.Encode(j)
+	if err != nil {
+		return nil, err
+	}
+	return buff.Bytes(), nil
+}
+
+// NewFromBytes returns a Job instance from a byte representation.
+func NewFromBytes(b []byte) (*Job, error) {
+	j := &Job{}
+
+	buf := bytes.NewBuffer(b)
+	err := gob.NewDecoder(buf).Decode(j)
+	if err != nil {
+		return nil, err
+	}
+
+	return j, nil
 }
 
 // Init fills in the protected fields and parses the iso8601 notation.

--- a/job/storage/boltdb.go
+++ b/job/storage/boltdb.go
@@ -103,12 +103,12 @@ func (db *BoltJobDB) Get(id string) (*job.Job, error) {
 	return j, nil
 }
 
-func (db *BoltJobDB) Delete(id string) {
-	db.dbConn.Update(func(tx *bolt.Tx) error {
+func (db *BoltJobDB) Delete(id string) error {
+	err := db.dbConn.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(jobBucket)
-		bucket.Delete([]byte(id))
-		return nil
+		return bucket.Delete([]byte(id))
 	})
+	return err
 }
 
 func (db *BoltJobDB) Save(j *job.Job) error {

--- a/job/storage/boltdb.go
+++ b/job/storage/boltdb.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"bytes"
 	"encoding/gob"
-	"fmt"
 	"strings"
 	"time"
 
@@ -87,7 +86,7 @@ func (db *BoltJobDB) Get(id string) (*job.Job, error) {
 
 		v := b.Get([]byte(id))
 		if v == nil {
-			return fmt.Errorf("Job with id of %s not found.", id)
+			return job.ErrJobNotFound(id)
 		}
 
 		buf := bytes.NewBuffer(v)

--- a/job/storage/boltdb/boltdb.go
+++ b/job/storage/boltdb/boltdb.go
@@ -1,4 +1,4 @@
-package storage
+package boltdb
 
 import (
 	"bytes"

--- a/job/storage/boltdb/boltdb_test.go
+++ b/job/storage/boltdb/boltdb_test.go
@@ -1,4 +1,4 @@
-package storage
+package boltdb
 
 import (
 	"testing"

--- a/job/storage/redis/redis.go
+++ b/job/storage/redis/redis.go
@@ -1,0 +1,105 @@
+package redis
+
+import (
+	"github.com/garyburd/redigo/redis"
+
+	"github.com/ajvb/kala/job"
+	"github.com/ajvb/kala/utils/logging"
+)
+
+var (
+	log = logging.GetLogger("kala.job.storage")
+
+	// HashKey is the hash key where jobs are persisted.
+	HashKey = "kala:jobs"
+)
+
+// DB is concrete implementation of the JobDB interface, that uses Redis for persistence.
+type DB struct {
+	conn      redis.Conn
+	keyprefix string
+}
+
+// New instantiates a new DB.
+func New(address string) *DB {
+	conn, err := redis.Dial("tcp", address)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &DB{
+		conn: conn,
+	}
+}
+
+// GetAll returns all persisted Jobs.
+func (d DB) GetAll() ([]*job.Job, error) {
+	jobs := []*job.Job{}
+
+	vals, err := d.conn.Do("HVALS", HashKey)
+	if err != nil {
+		return jobs, err
+	}
+
+	for _, val := range vals.([]interface{}) {
+		j, err := job.NewFromBytes(val.([]byte))
+		if err != nil {
+			return nil, err
+		}
+
+		err = j.InitDelayDuration(false)
+		if err != nil {
+			return nil, err
+		}
+
+		jobs = append(jobs, j)
+	}
+
+	return jobs, nil
+}
+
+// Get returns a persisted Job.
+func (d DB) Get(id string) (*job.Job, error) {
+	val, err := d.conn.Do("HGET", HashKey, id)
+	if err != nil {
+		return nil, err
+	}
+	if val == nil {
+		return nil, job.ErrJobNotFound(id)
+	}
+
+	return job.NewFromBytes(val.([]byte))
+}
+
+// Delete deletes a persisted Job.
+func (d DB) Delete(id string) error {
+	_, err := d.conn.Do("HDEL", id)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Save persists a Job.
+func (d DB) Save(j *job.Job) error {
+	bytes, err := j.Bytes()
+	if err != nil {
+		return err
+	}
+
+	_, err = d.conn.Do("HSET", HashKey, j.Id, bytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Close closes the connection to Redis.
+func (d DB) Close() error {
+	err := d.conn.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/job/storage/redis/redis_test.go
+++ b/job/storage/redis/redis_test.go
@@ -1,0 +1,179 @@
+package redis
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ajvb/kala/job"
+	"github.com/rafaeljusto/redigomock"
+	"github.com/stretchr/testify/assert"
+)
+
+type testJob struct {
+	Job   *job.Job
+	Bytes []byte
+}
+
+var (
+	conn     = redigomock.NewConn()
+	db       = mockRedisDB()
+	cache    = job.NewMemoryJobCache(db, time.Second*60)
+	testJobs = initTestJobs(3)
+)
+
+// mockRedisDB returns a new DB with a mock Redis connection.
+func mockRedisDB() DB {
+	return DB{
+		conn: conn,
+	}
+}
+
+// testJobs initializes n testJobs
+func initTestJobs(n int) []testJob {
+	testJobs := []testJob{}
+
+	for i := 0; i < n; i++ {
+		j := job.GetMockJobWithGenericSchedule()
+		j.Init(cache)
+
+		bytes, err := j.Bytes()
+		if err != nil {
+			panic(err)
+		}
+		t := testJob{
+			Job:   j,
+			Bytes: bytes,
+		}
+
+		testJobs = append(testJobs, t)
+	}
+
+	return testJobs
+}
+
+func TestSaveJob(t *testing.T) {
+	testJob := testJobs[0]
+
+	// Expect a HSET operation to be performed the job hash key, job ID and encoded job
+	conn.Command("HSET", HashKey, testJob.Job.Id, testJob.Bytes).
+		Expect("ok")
+
+	err := db.Save(testJob.Job)
+	assert.Nil(t, err)
+
+	// Test error handling
+	conn.Command("HSET", HashKey, testJob.Job.Id, testJob.Bytes).
+		ExpectError(errors.New("Redis error"))
+
+	err = db.Save(testJob.Job)
+	assert.NotNil(t, err)
+}
+
+func TestGetJob(t *testing.T) {
+	testJob := testJobs[0]
+
+	// Expect a HGET operation to be preformed with the job hash key and job ID
+	conn.Command("HGET", HashKey, testJob.Job.Id).
+		Expect(testJob.Bytes).
+		ExpectError(nil)
+
+	storedJob, err := db.Get(testJob.Job.Id)
+	assert.Nil(t, err)
+
+	assert.WithinDuration(t, storedJob.NextRunAt, testJob.Job.NextRunAt, 100*time.Microsecond)
+	assert.Equal(t, testJob.Job.Name, storedJob.Name)
+	assert.Equal(t, testJob.Job.Id, storedJob.Id)
+	assert.Equal(t, testJob.Job.Command, storedJob.Command)
+	assert.Equal(t, testJob.Job.Schedule, storedJob.Schedule)
+	assert.Equal(t, testJob.Job.Owner, storedJob.Owner)
+	assert.Equal(t, testJob.Job.SuccessCount, storedJob.SuccessCount)
+
+	// Test error handling
+	conn.Command("HGET", HashKey, testJob.Job.Id).
+		ExpectError(errors.New("Redis error"))
+
+	storedJob, err = db.Get(testJob.Job.Id)
+	assert.NotNil(t, err)
+}
+
+func TestDeleteJob(t *testing.T) {
+	testJob := testJobs[0]
+
+	// Expect a HDEL operation to be preformed with the job ID
+	conn.Command("HDEL", testJob.Job.Id).
+		Expect("ok").
+		ExpectError(nil)
+
+	err := db.Delete(testJob.Job.Id)
+	assert.Nil(t, err)
+
+	// Test error handling
+	conn.Command("HDEL", testJob.Job.Id).
+		ExpectError(errors.New("Redis error"))
+
+	err = db.Delete(testJob.Job.Id)
+	assert.NotNil(t, err)
+}
+
+func TestGetAllJobs(t *testing.T) {
+	// Expect a HVALS operation to be preformed with the job hash key
+	conn.Command("HVALS", HashKey).
+		Expect([]interface{}{
+		testJobs[0].Bytes,
+		testJobs[1].Bytes,
+		testJobs[2].Bytes,
+	}).
+		ExpectError(nil)
+
+	jobs, err := db.GetAll()
+	assert.Nil(t, err)
+
+	for i, j := range jobs {
+		assert.WithinDuration(t, testJobs[i].Job.NextRunAt, j.NextRunAt, 100*time.Microsecond)
+		assert.Equal(t, testJobs[i].Job.Name, j.Name)
+		assert.Equal(t, testJobs[i].Job.Id, j.Id)
+		assert.Equal(t, testJobs[i].Job.Command, j.Command)
+		assert.Equal(t, testJobs[i].Job.Schedule, j.Schedule)
+		assert.Equal(t, testJobs[i].Job.Owner, j.Owner)
+		assert.Equal(t, testJobs[i].Job.SuccessCount, j.SuccessCount)
+	}
+
+	// Test erorr handling
+	conn.Command("HVALS", HashKey).
+		ExpectError(errors.New("Redis error"))
+
+	jobs, err = db.GetAll()
+	assert.NotNil(t, err)
+}
+
+func TestNew(t *testing.T) {
+
+}
+
+func TestClose(t *testing.T) {
+	closedConn := false
+
+	conn.CloseMock = func() error {
+		closedConn = true
+		return nil
+	}
+
+	err := db.Close()
+
+	assert.Nil(t, err)
+	assert.True(t, closedConn)
+
+	// Reset closedConn
+	closedConn = false
+
+	conn.CloseMock = func() error {
+		closedConn = false
+		return errors.New("Error closing connection")
+	}
+
+	err = db.Close()
+
+	assert.NotNil(t, err)
+	assert.False(t, closedConn)
+}

--- a/job/test_utils.go
+++ b/job/test_utils.go
@@ -13,7 +13,9 @@ func (m *MockDB) GetAll() ([]*Job, error) {
 func (m *MockDB) Get(id string) (*Job, error) {
 	return nil, nil
 }
-func (m *MockDB) Delete(id string) {}
+func (m *MockDB) Delete(id string) error {
+	return nil
+}
 func (m *MockDB) Save(job *Job) error {
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ajvb/kala/api"
 	"github.com/ajvb/kala/job"
-	"github.com/ajvb/kala/job/storage"
+	"github.com/ajvb/kala/job/storage/boltdb"
 	"github.com/ajvb/kala/utils/logging"
 
 	"github.com/codegangsta/cli"
@@ -63,7 +63,7 @@ func main() {
 					connectionString = parsedPort
 				}
 
-				db := storage.GetBoltDB(c.String("boltpath"))
+				db := boltdb.GetBoltDB(c.String("boltpath"))
 
 				// Create cache
 				cache := job.NewMemoryJobCache(db, DefaultPersistEvery)

--- a/main.go
+++ b/main.go
@@ -9,14 +9,17 @@ import (
 	"github.com/ajvb/kala/api"
 	"github.com/ajvb/kala/job"
 	"github.com/ajvb/kala/job/storage/boltdb"
+	"github.com/ajvb/kala/job/storage/redis"
 	"github.com/ajvb/kala/utils/logging"
 
 	"github.com/codegangsta/cli"
 )
 
 var (
-	log                 = logging.GetLogger("kala")
 	DefaultPersistEvery = 5 * time.Second
+
+	db  job.JobDB
+	log = logging.GetLogger("kala")
 )
 
 func main() {
@@ -34,17 +37,27 @@ func main() {
 				cli.IntFlag{
 					Name:  "port, p",
 					Value: 8000,
-					Usage: "port for Kala to run on",
+					Usage: "Port for Kala to run on.",
 				},
 				cli.StringFlag{
 					Name:  "interface, i",
 					Value: "",
-					Usage: "Interface to listen on, default is all",
+					Usage: "Interface to listen on, default is all.",
+				},
+				cli.StringFlag{
+					Name:  "jobDB",
+					Value: "boltdb",
+					Usage: "Implementation of job database, either 'boltdb' or 'redis'.",
 				},
 				cli.StringFlag{
 					Name:  "boltpath",
 					Value: "",
 					Usage: "Path to the bolt database file, default is current directory.",
+				},
+				cli.StringFlag{
+					Name:  "jobDBAddress",
+					Value: "127.0.0.1:6379",
+					Usage: "Network address for the job database, in 'host:port' format.",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -63,7 +76,14 @@ func main() {
 					connectionString = parsedPort
 				}
 
-				db := boltdb.GetBoltDB(c.String("boltpath"))
+				switch c.String("jobDB") {
+				case "boltdb":
+					db = boltdb.GetBoltDB(c.String("boltpath"))
+				case "redis":
+					db = redis.New(c.String("jobDBAddress"))
+				default:
+					log.Fatalf("Unknown Job DB implementation '%s'", c.String("jobDB"))
+				}
 
 				// Create cache
 				cache := job.NewMemoryJobCache(db, DefaultPersistEvery)


### PR DESCRIPTION
Adds a Redis implementation of JobDB interface, which can be used by running:

```
kala run --jobDB=redis --jobDBAddress=127.0.0.1:6379
```

Jobs are stored in Redis using a single hash, rather than a name spaced key for each job. This allows `GetAll` to perform only `HVALS` instead of `SCAN` and then `GET` when retrieving all jobs. In additional, it also helps Kala *'play nice'* when sharing Redis with others, by using a single key - `kala:jobs`.

Addresses https://github.com/ajvb/kala/issues/43