### PR TITLE
Stricter ISO 8601 duration parsing

### DIFF
--- a/job/job_scheduling_test.go
+++ b/job/job_scheduling_test.go
@@ -46,7 +46,7 @@ var getWaitDurationTableTests = []struct {
 		JobFunc: func() *Job {
 			return &Job{
 				// Schedule time is passed
-				Schedule: "R/2015-10-17T11:44:54.389361-07:00/P1DT",
+				Schedule: "R/2015-10-17T11:44:54.389361-07:00/P1D",
 				Metadata: Metadata{
 					LastAttemptedRun: time.Now(),
 				},

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -93,7 +93,7 @@ var delayParsingTests = []struct {
 	{time.Hour*24 + time.Second*10 + time.Minute*10, "P1DT10M10S"},
 	{time.Second*10 + time.Minute*10, "PT10M10S"},
 	{time.Hour*24 + time.Second*10, "P1DT10S"},
-	{time.Hour*24*365 + time.Hour*24, "P1Y1DT"},
+	{time.Hour*24*365 + time.Hour*24, "P1Y1D"},
 }
 
 func TestDelayParsing(t *testing.T) {

--- a/utils/iso8601/iso8601_test.go
+++ b/utils/iso8601/iso8601_test.go
@@ -31,6 +31,51 @@ func TestFromString(t *testing.T) {
 	dur, err = iso8601.FromString("P1W")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, dur.Weeks)
+
+	// test with 2M
+	dur, err = iso8601.FromString("P2M")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, dur.Years)
+	assert.Equal(t, 2, dur.Months)
+	assert.Equal(t, 0, dur.Days)
+	assert.Equal(t, 0, dur.Hours)
+	assert.Equal(t, 0, dur.Minutes)
+	assert.Equal(t, 0, dur.Seconds)
+
+	// test with invalid
+	dur, err = iso8601.FromString("PT")
+	assert.Nil(t, dur)
+	assert.Equal(t, err.Error(), "invalid ISO 8601 duration spec PT")
+
+	// test with 4h
+	dur, err = iso8601.FromString("PT4H")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, dur.Years)
+	assert.Equal(t, 0, dur.Months)
+	assert.Equal(t, 0, dur.Days)
+	assert.Equal(t, 4, dur.Hours)
+	assert.Equal(t, 0, dur.Minutes)
+	assert.Equal(t, 0, dur.Seconds)
+
+	// test with 5m
+	dur, err = iso8601.FromString("PT5M")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, dur.Years)
+	assert.Equal(t, 0, dur.Months)
+	assert.Equal(t, 0, dur.Days)
+	assert.Equal(t, 0, dur.Hours)
+	assert.Equal(t, 5, dur.Minutes)
+	assert.Equal(t, 0, dur.Seconds)
+
+	// test with 6s
+	dur, err = iso8601.FromString("PT6S")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, dur.Years)
+	assert.Equal(t, 0, dur.Months)
+	assert.Equal(t, 0, dur.Days)
+	assert.Equal(t, 0, dur.Hours)
+	assert.Equal(t, 0, dur.Minutes)
+	assert.Equal(t, 6, dur.Seconds)
 }
 
 func TestString(t *testing.T) {


### PR DESCRIPTION
As a common mistake, one can specify a string like "P1S" instead of "PT1S" that is not a valid ISO 8601 duration spec.  For now it doesn't end up with any errors and result in a Duration with all fields being zeroes.  This patch make the parser reject such wrong specs.
