### PR TITLE
Fix Redis Delete Command

### DIFF
--- a/job/storage/redis/redis.go
+++ b/job/storage/redis/redis.go
@@ -70,7 +70,7 @@ func (d DB) Get(id string) (*job.Job, error) {
 
 // Delete deletes a persisted Job.
 func (d DB) Delete(id string) error {
-	_, err := d.conn.Do("HDEL", id)
+	_, err := d.conn.Do("HDEL", HashKey, id)
 	if err != nil {
 		return err
 	}

--- a/job/storage/redis/redis_test.go
+++ b/job/storage/redis/redis_test.go
@@ -101,7 +101,7 @@ func TestDeleteJob(t *testing.T) {
 	testJob := testJobs[0]
 
 	// Expect a HDEL operation to be preformed with the job ID
-	conn.Command("HDEL", testJob.Job.Id).
+	conn.Command("HDEL", HashKey, testJob.Job.Id).
 		Expect("ok").
 		ExpectError(nil)
 
@@ -109,7 +109,7 @@ func TestDeleteJob(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test error handling
-	conn.Command("HDEL", testJob.Job.Id).
+	conn.Command("HDEL", HashKey, testJob.Job.Id).
 		ExpectError(errors.New("Redis error"))
 
 	err = db.Delete(testJob.Job.Id)


### PR DESCRIPTION
The HashKey was not specified in HDEL command, causing an
error when saving jobs to Redis

Fixed this and updated tests