### PR TITLE
This fix issue #118

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -266,6 +266,10 @@ func (j *Job) GetWaitDuration() time.Duration {
 	waitDuration := time.Duration(j.scheduleTime.UnixNano() - time.Now().UnixNano())
 
 	if waitDuration < 0 {
+		if j.timesToRepeat == 0 {
+			return 0
+		}
+
 		if j.Metadata.LastAttemptedRun.IsZero() {
 			waitDuration = j.delayDuration.ToDuration()
 		} else {

--- a/job/job_scheduling_test.go
+++ b/job/job_scheduling_test.go
@@ -45,6 +45,19 @@ var getWaitDurationTableTests = []struct {
 	{
 		JobFunc: func() *Job {
 			return &Job{
+				// Schedule time is passed, no repetitions
+				Schedule: "R0/2015-10-17T11:44:54.389361-07:00/",
+				Metadata: Metadata{
+					LastAttemptedRun: time.Time{},
+				},
+			}
+		},
+		ExpectedDuration: 0 * time.Second,
+		Name:             "Passed time, 0 seconds",
+	},
+	{
+		JobFunc: func() *Job {
+			return &Job{
 				// Schedule time is passed
 				Schedule: "R/2015-10-17T11:44:54.389361-07:00/P1D",
 				Metadata: Metadata{


### PR DESCRIPTION
Fixing bug on job without repetition and interval specified that causes panic if its time has passed when kala was off. Issue #118 

Added control on `GetWaitDuration()` function and test 