### PR TITLE
Fix issue #120 - Not-fixed times recurring job bug

### DIFF
--- a/job/cache_test.go
+++ b/job/cache_test.go
@@ -1,10 +1,10 @@
 package job
 
 import (
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCacheStart(t *testing.T) {
@@ -22,4 +22,35 @@ func TestCachePersist(t *testing.T) {
 	cache := NewMockCache()
 	err := cache.Persist()
 	assert.NoError(t, err)
+}
+
+type MockDBGetAll struct {
+	MockDB
+	response []*Job
+}
+
+func (d *MockDBGetAll) GetAll() ([]*Job, error) {
+	return d.response, nil
+}
+
+func TestCacheStartStartsARecurringJobWithStartDateInThePast(t *testing.T) {
+
+	cache := NewMockCache()
+	mockDb := &MockDBGetAll{}
+	cache.jobDB = mockDb
+
+	pastDate := time.Date(2016, time.April, 12, 20, 00, 00, 0, time.UTC)
+	j := GetMockRecurringJobWithSchedule(pastDate, "PT1S")
+	j.Id = "0"
+
+	jobs := make([]*Job, 0, 0)
+	jobs = append(jobs, j)
+	mockDb.response = jobs
+
+	cache.Start(0)
+	time.Sleep(time.Second * 2)
+
+	j.lock.RLock()
+	assert.Equal(t, j.Metadata.SuccessCount, uint(1))
+	j.lock.RUnlock()
 }

--- a/job/job.go
+++ b/job/job.go
@@ -415,13 +415,19 @@ func (j *Job) RunCmd() error {
 	return jobRunner.runCmd()
 }
 
-func (j *Job) ShouldStartWaiting() bool {
+func (j *Job) hasFixedRepetitions() bool {
+	if j.timesToRepeat != -1 {
+		return true
+	}
+	return false
+}
 
+func (j *Job) ShouldStartWaiting() bool {
 	if j.Disabled {
 		return false
 	}
 
-	if int(j.timesToRepeat) < len(j.Stats) {
+	if j.hasFixedRepetitions() && int(j.timesToRepeat) < len(j.Stats) {
 		return false
 	}
 	return true

--- a/job/test_utils.go
+++ b/job/test_utils.go
@@ -3,6 +3,8 @@ package job
 import (
 	"fmt"
 	"time"
+
+	"github.com/ajvb/kala/utils/iso8601"
 )
 
 type MockDB struct{}
@@ -42,6 +44,21 @@ func GetMockJobWithSchedule(repeat int, scheduleTime time.Time, delay string) *J
 	parsedTime := scheduleTime.Format(time.RFC3339)
 	scheduleStr := fmt.Sprintf("R%d/%s/%s", repeat, parsedTime, delay)
 	genericMockJob.Schedule = scheduleStr
+
+	return genericMockJob
+}
+
+func GetMockRecurringJobWithSchedule(scheduleTime time.Time, delay string) *Job {
+	genericMockJob := GetMockJob()
+
+	parsedTime := scheduleTime.Format(time.RFC3339)
+	scheduleStr := fmt.Sprintf("R/%s/%s", parsedTime, delay)
+	genericMockJob.Schedule = scheduleStr
+	genericMockJob.timesToRepeat = -1
+
+	parsedDuration, _ := iso8601.FromString(delay)
+
+	genericMockJob.delayDuration = parsedDuration
 
 	return genericMockJob
 }


### PR DESCRIPTION
Issue: #120 

Fixed the bug adding a function to check if a job has fixed repetitions before checking stats len and timesToRepeat to avoid problem in case of recurring job (timesToRepeat = -1). With tests.

Special thanks to @benwaine that help me on tests!

