### PR TITLE
Fixes as a result of running staticcheck

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -318,4 +318,5 @@ func unmarshallRequestBody(t assert.TestingT, resp *http.Response, obj interface
 	assert.NoError(t, err)
 	resp.Body.Close()
 	err = json.Unmarshal(body, obj)
+	assert.NoError(t, err)
 }

--- a/job/cache.go
+++ b/job/cache.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -70,7 +71,7 @@ func (c *MemoryJobCache) Start(persistWaitTime time.Duration) {
 
 	// Process-level defer for shutting down the db.
 	ch := make(chan os.Signal)
-	signal.Notify(ch, os.Interrupt, os.Kill)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		s := <-ch
 		log.Infof("Process got signal: %s", s)
@@ -82,7 +83,7 @@ func (c *MemoryJobCache) Start(persistWaitTime time.Duration) {
 		// Close the database
 		c.jobDB.Close()
 
-		os.Exit(1)
+		os.Exit(0)
 	}()
 }
 


### PR DESCRIPTION
Two "problems" were detected as a result of running staticcheck,
this fixes them.

1. Nothing is done with the 2nd err in unmarshallRequestBody
2. You can't catch sig kill