### PR TITLE
Remote support (WIP)

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -76,6 +76,11 @@ type Job struct {
 	// Meta data about successful and failed runs.
 	Metadata Metadata `json:"metadata"`
 
+	// Type of the job
+	JobType jobType `json:"type"`
+
+	RemoteProperties RemoteProperties `json:"remote_proporties"`
+
 	// Collection of Job Stats
 	Stats []*JobStat `json:"stats"`
 
@@ -86,12 +91,33 @@ type Job struct {
 	IsDone bool `json:"is_done"`
 }
 
+type jobType int
+
+const (
+	LocalJob jobType = 0 + iota
+	RemoteJob
+)
+
+type RemoteProperties struct {
+	Url                  string   `json:"url"`
+	Method               string   `json:"method"`
+	Body                 string   `json:"body"`
+	Headers              []Header `json:"headers"`
+	Timeout              int      `json:"timeout"`
+	ExpectedResponseCode []int    `json:"expected_response_codes"`
+}
+
 type Metadata struct {
 	SuccessCount     uint      `json:"success_count"`
 	LastSuccess      time.Time `json:"last_success"`
 	ErrorCount       uint      `json:"error_count"`
 	LastError        time.Time `json:"last_error"`
 	LastAttemptedRun time.Time `json:"last_attempted_run"`
+}
+
+type Header struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // Bytes returns the byte representation of the Job.

--- a/job/job.go
+++ b/job/job.go
@@ -99,12 +99,12 @@ const (
 )
 
 type RemoteProperties struct {
-	Url                  string   `json:"url"`
-	Method               string   `json:"method"`
-	Body                 string   `json:"body"`
-	Headers              []Header `json:"headers"`
-	Timeout              int      `json:"timeout"`
-	ExpectedResponseCode []int    `json:"expected_response_codes"`
+	Url                   string   `json:"url"`
+	Method                string   `json:"method"`
+	Body                  string   `json:"body"`
+	Headers               []Header `json:"headers"`
+	Timeout               int      `json:"timeout"`
+	ExpectedResponseCodes []int    `json:"expected_response_codes"`
 }
 
 type Metadata struct {

--- a/job/runner.go
+++ b/job/runner.go
@@ -1,14 +1,14 @@
 package job
 
 import (
-	"errors"
-	"os/exec"
-	"time"
-
-	"bytes"
-	log "github.com/Sirupsen/logrus"
-	"net/http"
 	"strings"
+	"errors"
+	"time"
+	"bytes"
+	"net/http"
+	"os/exec"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type JobRunner struct {
@@ -186,10 +186,10 @@ func (j *JobRunner) collectStats(success bool) {
 
 func (j *JobRunner) checkExpected(statusCode int) bool {
 	// If no expected response codes passed, add 200 status code as expected
-	if len(j.job.RemoteProperties.ExpectedResponseCode) == 0 {
-		j.job.RemoteProperties.ExpectedResponseCode = append(j.job.RemoteProperties.ExpectedResponseCode, 200)
+	if len(j.job.RemoteProperties.ExpectedResponseCodes) == 0 {
+		j.job.RemoteProperties.ExpectedResponseCodes = append(j.job.RemoteProperties.ExpectedResponseCodes, 200)
 	}
-	for _, expected := range j.job.RemoteProperties.ExpectedResponseCode {
+	for _, expected := range j.job.RemoteProperties.ExpectedResponseCodes {
 		if expected == statusCode {
 			return true
 		}


### PR DESCRIPTION
Added support for jobType as discussed in #73 with a remote job type

basically it adds the following support:

if user passed `job_type: 1` in the create job json, it allows her/him to specify `remote_properties`:

- `url`, allows to configure to what url to send the request
- `method`, specifying the method to use
- `body`, allows adding a body to the http request
- `headers`, a list of headers as jsons (`{"key": "k", "value": "v"}`
- `timeout`, after how long to declare the request as failure if there is no response
- `expected_response_codes`, a list of ints to specify which response codes are declared as success

all params have default values and all except for `url` are optional

this is not finished, but would like to hear if it's a good direction and if so, will add tests and examples when I can