### PR TITLE
when jobDBPassword=""or not input jobDBPassword para 

### DIFF
--- a/job/storage/redis/redis.go
+++ b/job/storage/redis/redis.go
@@ -29,6 +29,16 @@ func New(address string, password redis.DialOption) *DB {
 	}
 }
 
+func Newnopass(address string) *DB {
+	conn, err := redis.Dial("tcp", address)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &DB{
+		conn: conn,
+	}
+}
+
 // GetAll returns all persisted Jobs.
 func (d DB) GetAll() ([]*job.Job, error) {
 	jobs := []*job.Job{}

--- a/main.go
+++ b/main.go
@@ -133,11 +133,11 @@ func main() {
 				case "boltdb":
 					db = boltdb.GetBoltDB(c.String("boltpath"))
 				case "redis":
-					if c.String("jobDBPassword") != "" {
+					if c.String("jobDBPassword") != "" && c.String("jobDBPassword") != "password" {
 						option := redislib.DialPassword(c.String("jobDBPassword"))
 						db = redis.New(c.String("jobDBAddress"), option)
 					} else {
-						db = redis.New(c.String("jobDBAddress"), redislib.DialOption{})
+						db = redis.Newnopass(c.String("jobDBAddress"))
 					}
 				default:
 					log.Fatalf("Unknown Job DB implementation '%s'", c.String("jobDB"))


### PR DESCRIPTION
when i use following args run , it has some errors..
//my redis is not set passwd for connection
./kala run -p 40001 --jobDB=redis --jobDBAddress=192.168.6.151:6379
FATA[0000] ERR Client sent AUTH, but no password is set

./kala run -p 40001 --jobDB=redis --jobDBAddress=192.168.6.151:6379 --jobDBPassword=""
panic: runtime error: invalid memory address or nil pointer dereference

1.Because of default jobDBPassword is 'password' 
2.Because of DialOption in kala/job/storage/redis.go is nil and redigo/redis will get error in calling Dial func.
//redigo/redis/conn.go
for _, option := range options {
        option.f(&do)
 }

So, i add Newnopass func for no password args call redis.Dial("tcp", address), it tests OK. 
Please check if it needs merge,  thx.

