### PR TITLE
when jobDBPassword=""or not input jobDBPassword para

### DIFF
--- a/job/storage/redis/redis.go
+++ b/job/storage/redis/redis.go
@@ -19,18 +19,14 @@ type DB struct {
 }
 
 // New instantiates a new DB.
-func New(address string, password redis.DialOption) *DB {
-	conn, err := redis.Dial("tcp", address, password)
-	if err != nil {
-		log.Fatal(err)
+func New(address string, password redis.DialOption, passinterface int) *DB {
+	var conn redis.Conn
+	var err error
+	if passinterface == 1 {
+		conn, err = redis.Dial("tcp", address, password)
+	} else {
+		conn, err = redis.Dial("tcp", address)
 	}
-	return &DB{
-		conn: conn,
-	}
-}
-
-func Newnopass(address string) *DB {
-	conn, err := redis.Dial("tcp", address)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/job/storage/redis/redis.go
+++ b/job/storage/redis/redis.go
@@ -29,6 +29,16 @@ func New(address string, password redis.DialOption) *DB {
 	}
 }
 
+func Newnopass(address string) *DB {
+	conn, err := redis.Dial("tcp", address)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return &DB{
+		conn: conn,
+	}
+}
+
 // GetAll returns all persisted Jobs.
 func (d DB) GetAll() ([]*job.Job, error) {
 	jobs := []*job.Job{}

--- a/job/storage/redis/redis.go
+++ b/job/storage/redis/redis.go
@@ -19,10 +19,10 @@ type DB struct {
 }
 
 // New instantiates a new DB.
-func New(address string, password redis.DialOption, sendPassword int) *DB {
+func New(address string, password redis.DialOption, sendPassword bool) *DB {
 	var conn redis.Conn
 	var err error
-	if sendPassword == 1 {
+	if sendPassword {
 		conn, err = redis.Dial("tcp", address, password)
 	} else {
 		conn, err = redis.Dial("tcp", address)

--- a/job/storage/redis/redis.go
+++ b/job/storage/redis/redis.go
@@ -19,10 +19,10 @@ type DB struct {
 }
 
 // New instantiates a new DB.
-func New(address string, password redis.DialOption, passinterface int) *DB {
+func New(address string, password redis.DialOption, sendPassword int) *DB {
 	var conn redis.Conn
 	var err error
-	if passinterface == 1 {
+	if sendPassword == 1 {
 		conn, err = redis.Dial("tcp", address, password)
 	} else {
 		conn, err = redis.Dial("tcp", address)

--- a/main.go
+++ b/main.go
@@ -135,9 +135,9 @@ func main() {
 				case "redis":
 					if c.String("jobDBPassword") != "" {
 						option := redislib.DialPassword(c.String("jobDBPassword"))
-						db = redis.New(c.String("jobDBAddress"), option, 1)
+						db = redis.New(c.String("jobDBAddress"), option, true)
 					} else {
-						db = redis.New(c.String("jobDBAddress"), redislib.DialOption{}, 0)
+						db = redis.New(c.String("jobDBAddress"), redislib.DialOption{}, false)
 					}
 				default:
 					log.Fatalf("Unknown Job DB implementation '%s'", c.String("jobDB"))

--- a/main.go
+++ b/main.go
@@ -133,11 +133,11 @@ func main() {
 				case "boltdb":
 					db = boltdb.GetBoltDB(c.String("boltpath"))
 				case "redis":
-					if c.String("jobDBPassword") != "" {
+					if c.String("jobDBPassword") != "" && c.String("jobDBPassword") != "password" {
 						option := redislib.DialPassword(c.String("jobDBPassword"))
 						db = redis.New(c.String("jobDBAddress"), option)
 					} else {
-						db = redis.New(c.String("jobDBAddress"), redislib.DialOption{})
+						db = redis.Newnopass(c.String("jobDBAddress"))
 					}
 				default:
 					log.Fatalf("Unknown Job DB implementation '%s'", c.String("jobDB"))

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "jobDBPassword",
-					Value: "password",
+					Value: "",
 					Usage: "Password for the job database, in 'password' format.",
 				},
 				cli.BoolFlag{
@@ -133,11 +133,11 @@ func main() {
 				case "boltdb":
 					db = boltdb.GetBoltDB(c.String("boltpath"))
 				case "redis":
-					if c.String("jobDBPassword") != "" && c.String("jobDBPassword") != "password" {
+					if c.String("jobDBPassword") != "" {
 						option := redislib.DialPassword(c.String("jobDBPassword"))
-						db = redis.New(c.String("jobDBAddress"), option)
+						db = redis.New(c.String("jobDBAddress"), option, 1)
 					} else {
-						db = redis.Newnopass(c.String("jobDBAddress"))
+						db = redis.New(c.String("jobDBAddress"), redislib.DialOption{}, 0)
 					}
 				default:
 					log.Fatalf("Unknown Job DB implementation '%s'", c.String("jobDB"))


### PR DESCRIPTION
//my redis is not set passwd for connection
./kala run -p 40001 --jobDB=redis --jobDBAddress=192.168.6.151:6379
FATA[0000] ERR Client sent AUTH, but no password is set

./kala run -p 40001 --jobDB=redis --jobDBAddress=192.168.6.151:6379 --jobDBPassword=""
panic: runtime error: invalid memory address or nil pointer dereference

1. Because of default jobDBPassword is 'password'
2. Because of DialOption in kala/job/storage/redis.go is nil and redigo/redis will get error in calling Dial func.
//redigo/redis/conn.go
for _, option := range options {
option.f(&do)
}

# fixed
1. I think we should change the default password to be empty string instead of password.
2. Instead of using Newnopass, I think we should do the if-else in the redis.New() on checking whether the DialOption is nil.
--- golang struct can not check whether it is nil when struct initialized, and DialOption struct also can not compare with empty DialOption struct because of the f func in it. So, I add para in redis.New() instead of add redis.Newnopass function.

Please check if it needs merge, Thanks.