### PR TITLE
Fix stat for NextRunAt time (#146)

### DIFF
--- a/job/stats.go
+++ b/job/stats.go
@@ -47,7 +47,7 @@ func NewKalaStats(cache JobCache) *KalaStats {
 
 		if nextRun.IsZero() {
 			nextRun = job.NextRunAt
-		} else if (nextRun.UnixNano() - job.NextRunAt.UnixNano()) < 0 {
+		} else if (nextRun.UnixNano() - job.NextRunAt.UnixNano()) > 0 {
 			nextRun = job.NextRunAt
 		}
 

--- a/job/stats_test.go
+++ b/job/stats_test.go
@@ -50,6 +50,7 @@ func TestKalaStats(t *testing.T) {
 	assert.Equal(t, kalaStat.DisabledJobs, 5)
 	assert.Equal(t, kalaStat.SuccessCount, uint(5))
 	assert.Equal(t, kalaStat.ErrorCount, uint(0))
+	assert.True(t, (nextRunAt.UnixNano()-kalaStat.NextRunAt.UnixNano()) > 0)
 	assert.WithinDuration(t, kalaStat.NextRunAt, nextRunAt, time.Second)
 	assert.WithinDuration(t, kalaStat.LastAttemptedRun, now, time.Millisecond*100)
 	assert.WithinDuration(t, kalaStat.CreatedAt, createdAt, time.Millisecond*100)


### PR DESCRIPTION
Fix #146 to have NextRunAt report the earliest time instead of latest.