### PR TITLE
Delete all jobs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Examples:
 |Getting a list of all Jobs | GET | /api/v1/job/ |
 |Getting a Job | GET | /api/v1/job/{id}/ |
 |Deleting a Job | DELETE | /api/v1/job/{id}/ |
+|Deleting all Jobs | DELETE | /api/v1/job/all |
 |Getting metrics about a certain Job | GET | /api/v1/job/stats/{id}/ |
 |Starting a Job manually | POST | /api/v1/job/start/{id}/ |
 |Getting app-level metrics | GET | /api/v1/stats/ |

--- a/api/api.go
+++ b/api/api.go
@@ -177,7 +177,7 @@ func HandleJobRequest(cache job.JobCache, db job.JobDB) func(w http.ResponseWrit
 		if r.Method == "DELETE" {
 			err = j.Delete(cache, db)
 			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
+				errorEncodeJSON(err, http.StatusInternalServerError, w)
 			} else {
 				w.WriteHeader(http.StatusNoContent)
 			}
@@ -192,7 +192,7 @@ func HandleJobRequest(cache job.JobCache, db job.JobDB) func(w http.ResponseWrit
 func HandleDeleteAllJobs(cache job.JobCache, db job.JobDB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := job.DeleteAll(cache, db); err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			errorEncodeJSON(err, http.StatusInternalServerError, w)
 		} else {
 			w.WriteHeader(http.StatusNoContent)
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -186,6 +186,18 @@ func HandleJobRequest(cache job.JobCache, db job.JobDB) func(w http.ResponseWrit
 	}
 }
 
+// HandleDeleteAllJobs is the handler for deleting all jobs
+// DELETE /api/v1/job/all
+func HandleDeleteAllJobs(cache job.JobCache, db job.JobDB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := job.DeleteAll(cache, db); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}
+}
+
 type JobResponse struct {
 	Job *job.Job `json:"job"`
 }
@@ -274,6 +286,8 @@ func HandleEnableJobRequest(cache job.JobCache) func(w http.ResponseWriter, r *h
 func SetupApiRoutes(r *mux.Router, cache job.JobCache, db job.JobDB, defaultOwner string) {
 	// Route for creating a job
 	r.HandleFunc(ApiJobPath, HandleAddJob(cache, defaultOwner)).Methods("POST")
+	// Route for deleting all jobs
+	r.HandleFunc(ApiJobPath+"all/", HandleDeleteAllJobs(cache, db)).Methods("DELETE")
 	// Route for deleting and getting a job
 	r.HandleFunc(ApiJobPath+"{id}/", HandleJobRequest(cache, db)).Methods("DELETE", "GET")
 	// Route for getting job stats

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -300,6 +300,60 @@ func (a *ApiTestSuite) TestHandleStartJobRequestNotFound() {
 	a.Equal(w.Code, http.StatusNotFound)
 }
 
+func (a *ApiTestSuite) TestHandleEnableJobRequest() {
+	t := a.T()
+	cache, job := generateJobAndCache()
+	r := mux.NewRouter()
+	r.HandleFunc(ApiJobPath+"enable/{id}", HandleEnableJobRequest(cache)).Methods("POST")
+	ts := httptest.NewServer(r)
+
+	job.Disable()
+
+	_, req := setupTestReq(t, "POST", ts.URL+ApiJobPath+"enable/"+job.Id, nil)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	a.NoError(err)
+
+	a.Equal(http.StatusNoContent, resp.StatusCode)
+
+	a.Equal(false, job.Disabled)
+}
+func (a *ApiTestSuite) TestHandleEnableJobRequestNotFound() {
+	t := a.T()
+	cache := job.NewMockCache()
+	handler := HandleEnableJobRequest(cache)
+	w, req := setupTestReq(t, "POST", ApiJobPath+"enable/asdasd", nil)
+	handler(w, req)
+	a.Equal(w.Code, http.StatusNotFound)
+}
+
+func (a *ApiTestSuite) TestHandleDisableJobRequest() {
+	t := a.T()
+	cache, job := generateJobAndCache()
+	r := mux.NewRouter()
+	r.HandleFunc(ApiJobPath+"disable/{id}", HandleDisableJobRequest(cache)).Methods("POST")
+	ts := httptest.NewServer(r)
+
+	_, req := setupTestReq(t, "POST", ts.URL+ApiJobPath+"disable/"+job.Id, nil)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	a.NoError(err)
+
+	a.Equal(http.StatusNoContent, resp.StatusCode)
+
+	a.Equal(true, job.Disabled)
+}
+func (a *ApiTestSuite) TestHandleDisableJobRequestNotFound() {
+	t := a.T()
+	cache := job.NewMockCache()
+	handler := HandleDisableJobRequest(cache)
+	w, req := setupTestReq(t, "POST", ApiJobPath+"disable/asdasd", nil)
+	handler(w, req)
+	a.Equal(w.Code, http.StatusNotFound)
+}
+
 func (a *ApiTestSuite) TestHandleKalaStatsRequest() {
 	cache, _ := generateJobAndCache()
 	jobTwo := job.GetMockJobWithGenericSchedule()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -153,6 +153,29 @@ func (a *ApiTestSuite) TestDeleteJobSuccess() {
 	a.Nil(cache.Get(job.Id))
 }
 
+func (a *ApiTestSuite) TestDeleteAllJobsSuccess() {
+	t := a.T()
+	db := &job.MockDB{}
+	cache, jobOne := generateJobAndCache()
+	jobTwo := job.GetMockJobWithGenericSchedule()
+	jobTwo.Init(cache)
+
+	r := mux.NewRouter()
+	r.HandleFunc(ApiJobPath+"all/", HandleDeleteAllJobs(cache, db)).Methods("DELETE")
+	ts := httptest.NewServer(r)
+
+	_, req := setupTestReq(t, "DELETE", ts.URL+ApiJobPath+"all/", nil)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	a.NoError(err)
+	a.Equal(resp.StatusCode, http.StatusNoContent)
+
+	a.Equal(0, len(cache.GetAll().Jobs))
+	a.Nil(cache.Get(jobOne.Id))
+	a.Nil(cache.Get(jobTwo.Id))
+}
+
 func (a *ApiTestSuite) TestHandleJobRequestJobDoesNotExist() {
 	t := a.T()
 	db := &job.MockDB{}

--- a/client/client.go
+++ b/client/client.go
@@ -155,6 +155,14 @@ func (kc *KalaClient) DeleteJob(id string) (bool, error) {
 	return true, nil
 }
 
+// DeleteAllJobs is used to delete all jobs from Kala
+// Example:
+// 		c := New("http://127.0.0.1:8000")
+//		ok, err := c.DeleteAllJobs()
+func (kc *KalaClient) DeleteAllJobs() (bool, error) {
+	return kc.DeleteJob("all")
+}
+
 // GetJobStats is used to retrieve stats about a Job from Kala by its ID.
 // Example:
 // 		c := New("http://127.0.0.1:8000")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/ajvb/kala/api"
 	"github.com/ajvb/kala/job"
 
+	"testing"
+
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func NewTestServer() *httptest.Server {
@@ -165,6 +166,27 @@ func TestDeleteJob(t *testing.T) {
 
 	respJob, err := kc.GetJob(id)
 	assert.Nil(t, respJob)
+
+	cleanUp()
+}
+
+func TestDeleteAllJobs(t *testing.T) {
+	ts := NewTestServer()
+	defer ts.Close()
+	kc := New(ts.URL)
+	j := NewJobMap()
+
+	for i := 0; i < 10; i++ {
+		_, err := kc.CreateJob(j)
+		assert.NoError(t, err)
+	}
+
+	ok, err := kc.DeleteAllJobs()
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	allJobs, err := kc.GetAllJobs()
+	assert.Empty(t, allJobs)
 
 	cleanUp()
 }

--- a/job/db_test.go
+++ b/job/db_test.go
@@ -1,0 +1,51 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelete(t *testing.T) {
+	db := &MockDB{}
+	cache := NewMockCache()
+	job := GetMockJobWithGenericSchedule()
+	job.Init(cache)
+
+	err := job.Delete(cache, db)
+	assert.NoError(t, err)
+
+	val, err := cache.Get(job.Id)
+	assert.Error(t, err)
+	assert.Nil(t, val)
+}
+
+func TestDeleteDoesNotExists(t *testing.T) {
+	db := &MockDB{}
+	cache := NewMockCache()
+	jobOne := GetMockJobWithGenericSchedule()
+	jobOne.Init(cache)
+	jobTwo := GetMockJobWithGenericSchedule()
+
+	err := jobTwo.Delete(cache, db)
+	assert.Error(t, err)
+
+	val, err := cache.Get(jobOne.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, jobOne, val)
+}
+
+func TestDeleteAll(t *testing.T) {
+	db := &MockDB{}
+	cache := NewMockCache()
+	for i := 0; i < 10; i++ {
+		job := GetMockJobWithGenericSchedule()
+		job.Init(cache)
+	}
+
+	err := DeleteAll(cache, db)
+	assert.NoError(t, err)
+
+	allJobs := cache.GetAll()
+	assert.Empty(t, allJobs.Jobs)
+}


### PR DESCRIPTION
This PR adds the ability to delete all jobs at once, as proposed in #147.

I decided to call method `DELETE /job/all`, although it is not quite suitable for REST. But I think it fits better than `DELETE /job`. 

I used the easiest way to implement the deletion - simply call `Delete` on each job in a loop. Another way to do it is to add methods `DeleteAll` to `Db` and `Cache`, but it extends interface and requires more work to be done.

Also, I added this method to the client.