### PR TITLE
Support for jobs triggered on failure of other jobs (#140)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.coverprofile
 .vscode/
 kala
+.idea/*

--- a/api/api.go
+++ b/api/api.go
@@ -137,7 +137,6 @@ func HandleAddJob(cache job.JobCache, defaultOwner string) func(http.ResponseWri
 
 		err = newJob.Init(cache)
 		if err != nil {
-			// TODO(itstehkman): should we run on_failure job here?
 			errStr := "Error occured when initializing the job"
 			log.Errorf(errStr+": %s", err)
 			http.Error(w, errStr, http.StatusBadRequest)

--- a/api/api.go
+++ b/api/api.go
@@ -137,6 +137,7 @@ func HandleAddJob(cache job.JobCache, defaultOwner string) func(http.ResponseWri
 
 		err = newJob.Init(cache)
 		if err != nil {
+			// TODO(itstehkman): should we run on_failure job here?
 			errStr := "Error occured when initializing the job"
 			log.Errorf(errStr+": %s", err)
 			http.Error(w, errStr, http.StatusBadRequest)

--- a/job/job.go
+++ b/job/job.go
@@ -516,5 +516,7 @@ func (j *Job) MarshalJSON() ([]byte, error) {
 
 // TODO(itstehkman): This could go in j.Metadata
 func (j *Job) NumberOfFinishedRuns() int {
+	j.lock.RLock()
+	defer j.lock.RUnlock()
 	return len(j.Stats)
 }

--- a/job/job.go
+++ b/job/job.go
@@ -119,11 +119,12 @@ type RemoteProperties struct {
 }
 
 type Metadata struct {
-	SuccessCount     uint      `json:"success_count"`
-	LastSuccess      time.Time `json:"last_success"`
-	ErrorCount       uint      `json:"error_count"`
-	LastError        time.Time `json:"last_error"`
-	LastAttemptedRun time.Time `json:"last_attempted_run"`
+	SuccessCount     	uint      `json:"success_count"`
+	LastSuccess      	time.Time `json:"last_success"`
+	ErrorCount       	uint      `json:"error_count"`
+	LastError        	time.Time `json:"last_error"`
+	LastAttemptedRun 	time.Time `json:"last_attempted_run"`
+	NumberOfFinishedRuns	uint	  `json:"number_of_finished_runs"`
 }
 
 // Bytes returns the byte representation of the Job.
@@ -412,7 +413,7 @@ func (j *Job) DeleteFromDependentJobs(cache JobCache) error {
 	return nil
 }
 
-// Runs the on failure job, if it exists. Does not lock the job - it is up to you to do this
+// Runs the on failure job, if it exists. Does not lock the parent job - it is up to you to do this
 // however you want
 func (j *Job) RunOnFailureJob(cache JobCache) {
 	if (j.OnFailureJob != "") {
@@ -432,7 +433,6 @@ func (j *Job) Run(cache JobCache) {
 	j.lock.RUnlock()
 	newStat, newMeta, err := jobRunner.Run(cache)
 	if err != nil {
-		// TODO: run on_failure job
 		log.Errorf("Error running job: %s", err)
 		j.lock.RLock()
 		j.RunOnFailureJob(cache)
@@ -512,11 +512,4 @@ func (j *Job) MarshalJSON() ([]byte, error) {
 	j.lock.RLock()
 	defer j.lock.RUnlock()
 	return json.Marshal(RJob(*j))
-}
-
-// TODO(itstehkman): This could go in j.Metadata
-func (j *Job) NumberOfFinishedRuns() int {
-	j.lock.RLock()
-	defer j.lock.RUnlock()
-	return len(j.Stats)
 }

--- a/job/runner.go
+++ b/job/runner.go
@@ -69,6 +69,7 @@ func (j *JobRunner) Run(cache JobCache) (*JobStat, Metadata, error) {
 			}
 
 			j.collectStats(false)
+			j.meta.NumberOfFinishedRuns++
 
 			// TODO: Wrap error into something better.
 			return j.currentStat, j.meta, err
@@ -79,6 +80,7 @@ func (j *JobRunner) Run(cache JobCache) (*JobStat, Metadata, error) {
 
 	log.Infof("Job %s:%s finished.", j.job.Name, j.job.Id)
 	j.meta.SuccessCount++
+	j.meta.NumberOfFinishedRuns++
 	j.meta.LastSuccess = time.Now()
 
 	j.collectStats(true)

--- a/job/test_utils.go
+++ b/job/test_utils.go
@@ -38,6 +38,16 @@ func GetMockJob() *Job {
 	}
 }
 
+
+func GetMockFailingJob() *Job {
+	return &Job{
+		Name:    "mock_failing_job",
+		Command: "asdf",
+		Owner:   "aj@ajvb.me",
+		Retries: 2,
+	}
+}
+
 func GetMockRemoteJob(props RemoteProperties) *Job {
 	return &Job{
 		Name:             "mock_remote_job",


### PR DESCRIPTION
Fixes #140. This PR allows you to define a job that gets triggered on failure of another job by setting OnFailureJob for a given Job. The test cases I've provided make sure that 1) this on failure job gets triggered on failure of the parent job 2) it does not get triggered when the parent job succeeds.

Some questions that may need to be answered and resolved are:
1) What happens if the on failure job gets triggered while it is already happening? Maybe we should specify a specific job type for on failure jobs only that disallows this? Or maybe we could just wait for the job to finish via its lock, and then run it when its done with its current run
2) How do you create these on failure jobs? Currently, I've shown via the test cases that you can add this job via the API, which may cause it to run on init depending on the schedule parameter. I do not feel like this is desired functionality, but I'll leave it up to you decide. I believe the desired functionality is that you create a job that never runs unless triggered on failure. 