### PR TITLE
Amend a typo in the routes overview table

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Examples:
 |Getting a list of all Jobs | GET | /api/v1/job/ |
 |Getting a Job | GET | /api/v1/job/{id}/ |
 |Deleting a Job | DELETE | /api/v1/job/{id}/ |
-|Deleting all Jobs | DELETE | /api/v1/job/all |
+|Deleting all Jobs | DELETE | /api/v1/job/all/ |
 |Getting metrics about a certain Job | GET | /api/v1/job/stats/{id}/ |
 |Starting a Job manually | POST | /api/v1/job/start/{id}/ |
 |Getting app-level metrics | GET | /api/v1/stats/ |


### PR DESCRIPTION
Just spotted this typo.