### PR TITLE
Log stdout & stderr from command

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -119,12 +119,12 @@ type RemoteProperties struct {
 }
 
 type Metadata struct {
-	SuccessCount     	uint      `json:"success_count"`
-	LastSuccess      	time.Time `json:"last_success"`
-	ErrorCount       	uint      `json:"error_count"`
-	LastError        	time.Time `json:"last_error"`
-	LastAttemptedRun 	time.Time `json:"last_attempted_run"`
-	NumberOfFinishedRuns	uint	  `json:"number_of_finished_runs"`
+	SuccessCount         uint      `json:"success_count"`
+	LastSuccess          time.Time `json:"last_success"`
+	ErrorCount           uint      `json:"error_count"`
+	LastError            time.Time `json:"last_error"`
+	LastAttemptedRun     time.Time `json:"last_attempted_run"`
+	NumberOfFinishedRuns uint      `json:"number_of_finished_runs"`
 }
 
 // Bytes returns the byte representation of the Job.
@@ -416,7 +416,7 @@ func (j *Job) DeleteFromDependentJobs(cache JobCache) error {
 // Runs the on failure job, if it exists. Does not lock the parent job - it is up to you to do this
 // however you want
 func (j *Job) RunOnFailureJob(cache JobCache) {
-	if (j.OnFailureJob != "") {
+	if j.OnFailureJob != "" {
 		onFailureJob, cacheErr := cache.Get(j.OnFailureJob)
 		if cacheErr == ErrJobDoesntExist {
 			log.Errorf("Error retrieving dependent job with id of %s", j.OnFailureJob)
@@ -433,7 +433,6 @@ func (j *Job) Run(cache JobCache) {
 	j.lock.RUnlock()
 	newStat, newMeta, err := jobRunner.Run(cache)
 	if err != nil {
-		log.Errorf("Error running job: %s", err)
 		j.lock.RLock()
 		j.RunOnFailureJob(cache)
 		j.lock.RUnlock()


### PR DESCRIPTION
This PR takes the combined output of the command and logs it even when "-v" is not used. Logging the output is very useful in debugging jobs. gofmt updated some formatting.