### PR TITLE
Enable/Disable, Delayed Resume, Cleanup

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,9 +10,9 @@ import (
 	"github.com/ajvb/kala/api/middleware"
 	"github.com/ajvb/kala/job"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/codegangsta/negroni"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -319,12 +319,15 @@ func SetupApiRoutes(r *mux.Router, cache job.JobCache, db job.JobDB, defaultOwne
 	r.HandleFunc(ApiUrlPrefix+"stats/", HandleKalaStatsRequest(cache)).Methods("GET")
 }
 
-func StartServer(listenAddr string, cache job.JobCache, db job.JobDB, defaultOwner string) error {
+func MakeServer(listenAddr string, cache job.JobCache, db job.JobDB, defaultOwner string) *http.Server {
 	r := mux.NewRouter()
 	// Allows for the use for /job as well as /job/
 	r.StrictSlash(true)
 	SetupApiRoutes(r, cache, db, defaultOwner)
 	n := negroni.New(negroni.NewRecovery(), &middleware.Logger{log.Logger{}})
 	n.UseHandler(r)
-	return http.ListenAndServe(listenAddr, n)
+	return &http.Server{
+		Addr:    listenAddr,
+		Handler: n,
+	}
 }

--- a/api/middleware/logger.go
+++ b/api/middleware/logger.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/codegangsta/negroni"
+	log "github.com/sirupsen/logrus"
 )
 
 // Logger is a middleware handler that logs the request as it goes in and the response as it goes out.

--- a/client/client.go
+++ b/client/client.go
@@ -199,3 +199,35 @@ func (kc *KalaClient) GetKalaStats() (*job.KalaStats, error) {
 	_, err := kc.do(methodGet, kc.url("stats"), http.StatusOK, nil, ks)
 	return ks.Stats, err
 }
+
+// DisableJob is used to disable a Job in Kala using its ID.
+// Example:
+// 		c := New("http://127.0.0.1:8000")
+//		id := "93b65499-b211-49ce-57e0-19e735cc5abd"
+//		ok, err := c.DisableJob(id)
+func (kc *KalaClient) DisableJob(id string) (bool, error) {
+	status, err := kc.do(methodPost, kc.url(jobPath, "disable", id), http.StatusNoContent, nil, nil)
+	if err != nil {
+		if err == GenericError {
+			return false, fmt.Errorf("Disable failed with a status code of %d", status)
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// EnableJob is used to enable a disabled Job in Kala using its ID.
+// Example:
+// 		c := New("http://127.0.0.1:8000")
+//		id := "93b65499-b211-49ce-57e0-19e735cc5abd"
+//		ok, err := c.EnableJob(id)
+func (kc *KalaClient) EnableJob(id string) (bool, error) {
+	status, err := kc.do(methodPost, kc.url(jobPath, "enable", id), http.StatusNoContent, nil, nil)
+	if err != nil {
+		if err == GenericError {
+			return false, fmt.Errorf("Enable failed with a status code of %d", status)
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -297,3 +297,37 @@ func TestGetKalaStats(t *testing.T) {
 
 	cleanUp()
 }
+
+func TestDisableEnableJob(t *testing.T) {
+
+	ts := NewTestServer()
+	defer ts.Close()
+	kc := New(ts.URL)
+	j := NewJobMap()
+
+	id, err := kc.CreateJob(j)
+	assert.NoError(t, err)
+	assert.NotEqual(t, id, "")
+
+	respJob, err := kc.GetJob(id)
+	assert.Nil(t, err)
+	assert.Equal(t, respJob.Disabled, false)
+
+	ok, err := kc.DisableJob(id)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	disJob, err := kc.GetJob(id)
+	assert.Nil(t, err)
+	assert.Equal(t, disJob.Disabled, true)
+
+	ok, err = kc.EnableJob(id)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	enJob, err := kc.GetJob(id)
+	assert.Nil(t, err)
+	assert.Equal(t, enJob.Disabled, false)
+
+	cleanUp()
+}

--- a/job/cache.go
+++ b/job/cache.go
@@ -9,8 +9,8 @@ import (
 	"time"
 	"unsafe"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/cornelk/hashmap"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -2,11 +2,11 @@ package job
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
-	"net/http/httptest"
-	"net/http"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -967,7 +967,7 @@ func TestRemoteJobBadStatusSuccess(t *testing.T) {
 	defer testServer.Close()
 
 	mockRemoteJob := GetMockRemoteJob(RemoteProperties{
-		Url: testServer.URL,
+		Url:                   testServer.URL,
 		ExpectedResponseCodes: []int{500},
 	})
 

--- a/job/runner.go
+++ b/job/runner.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/mattn/go-shellwords"
+	log "github.com/sirupsen/logrus"
 )
 
 type JobRunner struct {
@@ -176,7 +176,7 @@ func (j *JobRunner) shouldRetry() bool {
 	}
 
 	// Check Epsilon
-	if j.job.Epsilon != "" {
+	if j.job.Epsilon != "" && j.job.Schedule != "" {
 		if j.job.epsilonDuration.ToDuration() != 0 {
 			timeSinceStart := time.Now().Sub(j.job.NextRunAt)
 			timeLeftToRetry := j.job.epsilonDuration.ToDuration() - timeSinceStart

--- a/job/storage/boltdb/boltdb.go
+++ b/job/storage/boltdb/boltdb.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/ajvb/kala/job"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/job/storage/redis/redis.go
+++ b/job/storage/redis/redis.go
@@ -3,8 +3,8 @@ package redis
 import (
 	"github.com/ajvb/kala/job"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/garyburd/redigo/redis"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/job/storage/redis/redis_test.go
+++ b/job/storage/redis/redis_test.go
@@ -120,10 +120,10 @@ func TestGetAllJobs(t *testing.T) {
 	// Expect a HVALS operation to be preformed with the job hash key
 	conn.Command("HVALS", HashKey).
 		Expect([]interface{}{
-		testJobs[0].Bytes,
-		testJobs[1].Bytes,
-		testJobs[2].Bytes,
-	}).
+			testJobs[0].Bytes,
+			testJobs[1].Bytes,
+			testJobs[2].Bytes,
+		}).
 		ExpectError(nil)
 
 	jobs, err := db.GetAll()

--- a/main.go
+++ b/main.go
@@ -192,7 +192,8 @@ func main() {
 				cache.Start(time.Duration(c.Int("persist-every"))*time.Second, time.Duration(c.Int("jobstat-ttl"))*time.Minute)
 
 				log.Infof("Starting server on port %s", connectionString)
-				log.Fatal(api.StartServer(connectionString, cache, db, c.String("default-owner")))
+				srv := api.MakeServer(connectionString, cache, db, c.String("default-owner"))
+				log.Fatal(srv.ListenAndServe())
 			},
 		},
 	}


### PR DESCRIPTION
- Added Enable/Disable methods to the http client.
- If a job is paused and then resumes, and misses its fire point while paused, you can configure it so that it will wait until its *next* scheduled point rather than firing immediately.
- Little bit of prep to make the server more testable/cooperative.
- `go fmt ./...`