### PR TITLE
Job Completion Notification

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -102,6 +102,9 @@ type Job struct {
 	// Says if a job has been executed right numbers of time
 	// and should not been executed again in the future
 	IsDone bool `json:"is_done"`
+
+	// The job will send on this channel when it's done running; used for tests.
+	ranChan chan struct{}
 }
 
 type jobType int
@@ -486,6 +489,10 @@ func (j *Job) Run(cache JobCache) {
 		go j.StartWaiting(cache)
 	} else {
 		j.IsDone = true
+	}
+
+	if j.ranChan != nil {
+		j.ranChan <- struct{}{}
 	}
 
 	j.lock.Unlock()

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -234,10 +234,11 @@ func TestRecurringJobIsRepeating(t *testing.T) {
 	oneSecondFromNow := clk.Now().Add(time.Millisecond * 900)
 	j := GetMockRecurringJobWithSchedule(oneSecondFromNow, "PT5S")
 	j.Init(cache)
+	j.ranChan = make(chan struct{})
 
 	for i := 0; i < 2; i++ {
 		clk.AddTime(time.Millisecond * 6000)
-		time.Sleep(time.Second * 3)
+		awaitJobRan(t, j, time.Second*10)
 		now := clk.Now()
 		j.lock.RLock()
 		assert.WithinDuration(t, j.Metadata.LastSuccess, now, 2*time.Second)

--- a/job/test_utils.go
+++ b/job/test_utils.go
@@ -126,3 +126,13 @@ func parseTimeInLocation(t *testing.T, value string, location string) time.Time 
 func briefPause() {
 	time.Sleep(time.Millisecond * 100)
 }
+
+func awaitJobRan(t *testing.T, j *Job, timeout time.Duration) {
+	t.Helper()
+	briefPause()
+	select {
+	case <-j.ranChan:
+	case <-time.After(timeout):
+		t.Fatal("Job failed to run")
+	}
+}


### PR DESCRIPTION
Fixes #205 

Applies this new mechanism to the test `TestRecurringJobIsRepeating` which is the frequent failer, recently blocking #211 