### PR TITLE
Prevent deleted job to run

### DIFF
--- a/job/cache.go
+++ b/job/cache.go
@@ -19,6 +19,7 @@ var (
 
 type JobCache interface {
 	Get(id string) (*Job, error)
+	Has(id string) bool
 	GetAll() *JobsMap
 	Set(j *Job) error
 	Delete(id string) error
@@ -107,6 +108,15 @@ func (c *MemoryJobCache) Get(id string) (*Job, error) {
 	}
 
 	return j, nil
+}
+
+func (c *MemoryJobCache) Has(id string) bool {
+	c.jobs.Lock.RLock()
+	defer c.jobs.Lock.RUnlock()
+
+	j := c.jobs.Jobs[id]
+
+	return j != nil
 }
 
 func (c *MemoryJobCache) GetAll() *JobsMap {
@@ -281,6 +291,12 @@ func (c *LockFreeJobCache) Get(id string) (*Job, error) {
 		return nil, ErrJobDoesntExist
 	}
 	return j, nil
+}
+
+func (c *LockFreeJobCache) Has(id string) bool {
+	_, exists := c.jobs.GetStringKey(id)
+
+	return exists
 }
 
 func (c *LockFreeJobCache) GetAll() *JobsMap {

--- a/job/runner.go
+++ b/job/runner.go
@@ -27,6 +27,7 @@ type JobRunner struct {
 
 var (
 	ErrJobDisabled       = errors.New("Job cannot run, as it is disabled")
+	ErrJobDeleted        = errors.New("Job cannot run, as it is deleted")
 	ErrCmdIsEmpty        = errors.New("Job Command is empty.")
 	ErrJobTypeInvalid    = errors.New("Job Type is not valid.")
 	ErrInvalidDelimiters = errors.New("Job has invalid templating delimiters.")
@@ -40,6 +41,10 @@ func (j *JobRunner) Run(cache JobCache) (*JobStat, Metadata, error) {
 
 	j.meta.LastAttemptedRun = j.job.clk.Time().Now()
 
+	if !cache.Has(j.job.Id) {
+		log.Infof("Job %s with id %s tried to run, but exited early because its deleted", j.job.Name, j.job.Id)
+		return nil, j.meta, ErrJobDeleted
+	}
 	if j.job.Disabled {
 		log.Infof("Job %s tried to run, but exited early because its disabled.", j.job.Name)
 		return nil, j.meta, ErrJobDisabled


### PR DESCRIPTION
This PR solving #237 

As you can see in the original code: first job run, then checked Is It exists in the cache. 
We don't do anything if the job deleted: neither try to run nor reschedule it.